### PR TITLE
  Kotlin files that are included in library project ie copied from de…

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/MediaToolbarAction.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/MediaToolbarAction.kt
@@ -6,8 +6,11 @@ import org.wordpress.aztec.R
 import org.wordpress.aztec.toolbar.IToolbarAction
 import org.wordpress.aztec.toolbar.ToolbarActionType
 
+/**
+ * Class copied from demo app.
+ */
 enum class MediaToolbarAction constructor(override val buttonId: Int, override val actionType: ToolbarActionType,
-                                          override val textFormat: ITextFormat) : IToolbarAction {
-    GALLERY(R.id.media_bar_button_gallery, ToolbarActionType.OTHER, AztecTextFormat.FORMAT_NONE),
-    CAMERA(R.id.media_bar_button_camera, ToolbarActionType.OTHER, AztecTextFormat.FORMAT_NONE)
+                                          override val textFormats: Set<ITextFormat> = setOf()) : IToolbarAction {
+    GALLERY(R.id.media_bar_button_gallery, ToolbarActionType.OTHER, setOf(AztecTextFormat.FORMAT_NONE)),
+    CAMERA(R.id.media_bar_button_camera, ToolbarActionType.OTHER, setOf(AztecTextFormat.FORMAT_NONE))
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/MediaToolbarCameraButton.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/MediaToolbarCameraButton.kt
@@ -9,6 +9,9 @@ import org.wordpress.aztec.plugins.IMediaToolbarButton
 import org.wordpress.aztec.toolbar.AztecToolbar
 import org.wordpress.aztec.toolbar.IToolbarAction
 
+/**
+ * Class copied from demo app.
+ */
 class MediaToolbarCameraButton(val toolbar: AztecToolbar) : IMediaToolbarButton {
 
     private var clickListener: IMediaToolbarButton.IMediaToolbarClickListener? = null

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/MediaToolbarGalleryButton.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/MediaToolbarGalleryButton.kt
@@ -9,6 +9,9 @@ import org.wordpress.aztec.plugins.IMediaToolbarButton
 import org.wordpress.aztec.toolbar.AztecToolbar
 import org.wordpress.aztec.toolbar.IToolbarAction
 
+/**
+ * Class copied from demo app.
+ */
 class MediaToolbarGalleryButton(val toolbar: AztecToolbar) : IMediaToolbarButton {
 
     private var clickListener: IMediaToolbarButton.IMediaToolbarClickListener? = null


### PR DESCRIPTION
### Fix
3 kotlin files and many other drawables, layout from demo app copied and added to aztec library project which would be helpful while using this library. This commit has only the comment statement in 3 kotlin files. Layouts and drawable were included in the first commit of the forked project.

